### PR TITLE
:heavy_plus_sign: Swagger(springDoc Open API3) 관련 gradle 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   id("org.asciidoctor.jvm.convert") version "3.3.2"
   id("org.flywaydb.flyway") version "9.20.0"
   id("com.diffplug.spotless") version "6.19.0"
+  id("org.springdoc.openapi-gradle-plugin") version "1.6.0"
 }
 
 group = "com.team1415"
@@ -37,6 +38,8 @@ dependencies {
   implementation("org.flywaydb:flyway-core")
   implementation("org.flywaydb:flyway-mysql")
   implementation("org.mapstruct:mapstruct:1.5.5.Final")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.1.0")
   compileOnly("org.projectlombok:lombok")
   developmentOnly("org.springframework.boot:spring-boot-devtools")
   developmentOnly("org.springframework.boot:spring-boot-docker-compose")


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- 초기 gradle 설정 시 Swagger 관련 설정이 빠짐

# 어떻게 해결했나요?
- gradle에 `springdoc-openapi v2.1.0` dependency 및 plugin 추가

## Attachment
- https://springdoc.org/

## 체크리스트
- [x] 코드가 로컬에서 빌드되고 모든 테스트를 통과합니다.
- [ ] 적절한 문서를 추가하거나 기존 문서를 업데이트했습니다.
- [x] 변경 사항을 테스트하고 예상대로 작동하는지 확인했습니다.
- [ ] 코드를 검토하고 모든 코멘트와 제안사항에 대응했습니다.
