### PR TITLE
✨ Controller에 대한 공통 Response 생성 AOP 개발

### DIFF
--- a/src/main/java/com/team1415/soobookbackend/common/aop/ControllerResponseAdvice.java
+++ b/src/main/java/com/team1415/soobookbackend/common/aop/ControllerResponseAdvice.java
@@ -1,0 +1,34 @@
+package com.team1415.soobookbackend.common.aop;
+
+import com.team1415.soobookbackend.common.response.ApiNoContentCode;
+import com.team1415.soobookbackend.common.response.FailResponse;
+import com.team1415.soobookbackend.common.response.SuccessResponse;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ControllerResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+
+        if (ObjectUtils.isEmpty(body)) {
+            return FailResponse.of(new ApiNoContentCode(), "");
+        } else {
+            return SuccessResponse.of(body);
+        }
+    }
+}

--- a/src/main/java/com/team1415/soobookbackend/common/aop/ControllerResponseAdvice.java
+++ b/src/main/java/com/team1415/soobookbackend/common/aop/ControllerResponseAdvice.java
@@ -12,7 +12,7 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.team1415")
 public class ControllerResponseAdvice implements ResponseBodyAdvice<Object> {
 
     @Override

--- a/src/main/java/com/team1415/soobookbackend/common/response/ApiErrorCode.java
+++ b/src/main/java/com/team1415/soobookbackend/common/response/ApiErrorCode.java
@@ -4,5 +4,5 @@ public interface ApiErrorCode {
 
     int getCode();
 
-    int getMessage();
+    String getMessage();
 }

--- a/src/main/java/com/team1415/soobookbackend/common/response/ApiNoContentCode.java
+++ b/src/main/java/com/team1415/soobookbackend/common/response/ApiNoContentCode.java
@@ -1,0 +1,17 @@
+package com.team1415.soobookbackend.common.response;
+
+public class ApiNoContentCode implements ApiErrorCode{
+
+    public static final int NO_CONTENT_CODE = 204;
+    public static final String NO_CONTENT_MESSAGE = "조회 결과가 존재하지 않습니다.";
+
+    @Override
+    public int getCode() {
+        return NO_CONTENT_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return NO_CONTENT_MESSAGE;
+    }
+}

--- a/src/main/java/com/team1415/soobookbackend/common/response/ApiSuccessCode.java
+++ b/src/main/java/com/team1415/soobookbackend/common/response/ApiSuccessCode.java
@@ -1,0 +1,18 @@
+package com.team1415.soobookbackend.common.response;
+
+public class ApiSuccessCode implements ApiErrorCode {
+
+    public static final int SUCCESS_CODE = 200;
+    public static final String SUCCESS_MESSAGE = "성공적으로 처리하였습니다.";
+
+    @Override
+    public int getCode() {
+        return SUCCESS_CODE;
+    }
+
+    @Override
+    public String getMessage() {
+        return SUCCESS_MESSAGE;
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,18 +19,16 @@ spring:
       host: localhost
       port: 6379
 
-  springdoc:
-    version: '@project.version@'
-    api-docs:
-      path: /api-docs
-    default-consumes-media-type: application/json
-    default-produces-media-type: application/json
-    swagger-ui:
-      operations-sorter: alpha
-      tags-sorter: alpha
-      path: /swagger-ui.html
-      disable-swagger-default-url: true
-      display-query-params-without-oauth2: true
-      doc-expansion: none
-    paths-to-match:
-      - /api/**
+springdoc:
+  version: '@project.version@'
+  api-docs:
+    path: /v3/api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    operations-sorter: alpha
+    tags-sorter: alpha
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-query-params-without-oauth2: true
+    doc-expansion: none

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,3 +18,19 @@ spring:
       cache-null-values: true # null 캐싱 여부
       host: localhost
       port: 6379
+
+  springdoc:
+    version: '@project.version@'
+    api-docs:
+      path: /api-docs
+    default-consumes-media-type: application/json
+    default-produces-media-type: application/json
+    swagger-ui:
+      operations-sorter: alpha
+      tags-sorter: alpha
+      path: /swagger-ui.html
+      disable-swagger-default-url: true
+      display-query-params-without-oauth2: true
+      doc-expansion: none
+    paths-to-match:
+      - /api/**


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
### Controller의 return을 Response 클래스로 치환해주는 AOP 개발
- AOP 미적용 시 Controller에서 직접 Response 객체를 메소드마다 생성하여 반환해줘야 함

# 어떻게 해결했나요?
### `ResponseBodyAdvice`를 활용하여 AOP 적용
- `@RestControllerAdvice`를 사용하여 `@Controller` 클래스를 PointCut으로 하는 AOP 개발
     - `Controller` 클래스의 return을 정의해둔 Response 객체로 변환하여 반환해줌
- 샘플 Response Code로 `ApiSuccessCode, ApiNoContentCode` 추가

## Attachment
- Ref : https://devnm.tistory.com/28

## 체크리스트
- [x] 코드가 로컬에서 빌드되고 모든 테스트를 통과합니다.
- [ ] 적절한 문서를 추가하거나 기존 문서를 업데이트했습니다.
- [x] 변경 사항을 테스트하고 예상대로 작동하는지 확인했습니다.
- [ ] 코드를 검토하고 모든 코멘트와 제안사항에 대응했습니다.
