### PR TITLE
🐛  BookInformation 저장 시 ISBN10, 13이 Null로 저장되는 오류 수정

### DIFF
--- a/src/main/java/com/team1415/soobookbackend/book/domain/Book.java
+++ b/src/main/java/com/team1415/soobookbackend/book/domain/Book.java
@@ -3,7 +3,6 @@ package com.team1415.soobookbackend.book.domain;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
@@ -18,24 +17,24 @@ public class Book {
     private BookPublish bookPublish;
 
     public static Book create(String isbn, String title, BookPublish bookPublish) {
-        Book book = Book.builder().title(title).bookPublish(bookPublish).build();
+        Book book = Book.builder().isbn10("").isbn13("").title(title).bookPublish(bookPublish).build();
         book.updateIsbn(isbn);
         return book;
     }
 
     public void updateIsbn(String isbn) {
-        if (StringUtils.contains(isbn, " ")
-                && ArrayUtils.getLength(StringUtils.split(isbn, " ")) == 2) {
-            String[] splitedIsbn = StringUtils.split(isbn, " ");
-            this.isbn10 = splitedIsbn[0];
-            this.isbn13 = splitedIsbn[1];
+        if (Boolean.FALSE.equals(StringUtils.contains(isbn, " "))) {
             return;
         }
 
-        if (StringUtils.length(isbn) == 10) {
-            this.isbn10 = isbn;
-        } else if (StringUtils.length(isbn) == 13) {
-            this.isbn13 = isbn;
+        String[] splitedIsbns = StringUtils.split(isbn, " ");
+
+        for (String splitedIsbn : splitedIsbns) {
+            if (StringUtils.length(splitedIsbn) == 10) {
+                this.isbn10 = splitedIsbn;
+            } else if (StringUtils.length(splitedIsbn) == 13) {
+                this.isbn13 = splitedIsbn;
+            }
         }
     }
 }

--- a/src/main/java/com/team1415/soobookbackend/book/infrastructure/adapter/KakaoBookSearchApi.java
+++ b/src/main/java/com/team1415/soobookbackend/book/infrastructure/adapter/KakaoBookSearchApi.java
@@ -3,9 +3,6 @@ package com.team1415.soobookbackend.book.infrastructure.adapter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.team1415.soobookbackend.book.infrastructure.model.KakaoBookSearchApiResponse;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +12,10 @@ import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -37,7 +38,7 @@ public class KakaoBookSearchApi {
                 UriComponentsBuilder.fromHttpUrl(URL).queryParam("query", encodedQuery);
         HttpEntity<String> entity = new HttpEntity<>(httpHeaders);
 
-        Map responseBody =
+        var responseBody =
                 new RestTemplate()
                         .exchange(builder.toUriString(), HttpMethod.GET, entity, Map.class)
                         .getBody();

--- a/src/main/resources/db/migration/ddl/V0_0_1__create_table_book.sql
+++ b/src/main/resources/db/migration/ddl/V0_0_1__create_table_book.sql
@@ -1,7 +1,7 @@
 CREATE TABLE book (
   id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '도서아이디',
-  isbn10 VARCHAR(10) COMMENT '국제표준도서번호10자리',
-  isbn13 VARCHAR(13) COMMENT '국제표준도서번호13자리',
+  isbn10 VARCHAR(10) NOT NULL COMMENT '국제표준도서번호10자리',
+  isbn13 VARCHAR(13) NOT NULL COMMENT '국제표준도서번호13자리',
   title VARCHAR(255) NOT NULL COMMENT '도서명',
   publisher VARCHAR(255) NOT NULL COMMENT '출판사',
   price BIGINT COMMENT '도서정가',


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
### 카카오 도서검색 API 결과의 ISBN 파싱 로직 수정
- ISBN10, 13 중 한 개만 존재할 때 빈 스트링이 포함되어 있음

### MySQL에서 데이터가 없는 경우 빈 스트링으로 저장
- https://stackoverflow.com/questions/8470813/how-do-i-check-if-a-column-is-empty-or-null-in-mysql

# 어떻게 해결했나요?
### ISBN 파싱 로직 수정
- 빈 스트링이 무조건 존재하는 것에 맞춰서 로직 수정

### DDL 수정
- DDL에서 데이터가 없을 수 있는 필드도 Not Null로 지정

## Attachment
-

## 체크리스트
- [x] 코드가 로컬에서 빌드되고 모든 테스트를 통과합니다.
- [ ] 적절한 문서를 추가하거나 기존 문서를 업데이트했습니다.
- [x] 변경 사항을 테스트하고 예상대로 작동하는지 확인했습니다.
- [ ] 코드를 검토하고 모든 코멘트와 제안사항에 대응했습니다.
